### PR TITLE
Abyssal auto wave

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,15 +1,15 @@
 # Semi Auto Township
 
-This mod automatically heals and repairs your township town.
+This mod automatically heals and repairs your township town, as well as automatically fighting abyssal waves when optimal.
 
-Once township is profitable (with town halls), this allows you to fully idle township, without ever having to revisit your town to repair and heal.
+Once your township is profitable (with town halls), this allows you to fully idle township, without ever having to revisit your town to repair, heal, or handle abyssal waves.
 
 ## Settings
-In the mod settings you can set a cap that will prevent it from spending your whole bank on repairs. I.e. if you set it to 10,000,000 it will not repair if doing so would drop your GP pool under 10,000,000. This setting defaults to 0. I haven't been able to see what happens if the system tries to repair with insufficient funds, so if you see something unusual here please comment so I can address it.
+In the mod settings, you can set a cap that will prevent it from spending your whole bank on repairs. For example, if you set it to 10,000,000 GP, it will not repair if doing so would drop your GP pool under 10,000,000. This setting defaults to 0. If any issues arise from insufficient funds, please comment so I can address them.
 
-When healing, you can select what resource to use, either herbs or potions. By default, this mod will select the one for which you have the highest income.
+For healing, you can select what resource to use, either herbs or potions. By default, this mod will select the one for which you have the highest income.
+
+You can also enable an option to engage abyssal waves even if fortifications are not fully upgraded, although this will reduce XP efficiency and is reccomended to be left off.
 
 ## Help
-Repairing can be expensive at times so it may be inadvisable to turn this on until your town is profitable. 
-
-
+Repairing can be expensive at times, so it may be inadvisable to turn this on until your town is profitable.

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # Semi Auto Township
 
-This mod automatically heals and repairs your township town, as well as automatically fighting abyssal waves when optimal.
+This mod automatically heals and repairs your township town, as well as fighting abyssal waves when optimal.
 
 Once your township is profitable (with town halls), this allows you to fully idle township, without ever having to revisit your town to repair, heal, or handle abyssal waves.
 
@@ -9,7 +9,7 @@ In the mod settings, you can set a cap that will prevent it from spending your w
 
 For healing, you can select what resource to use, either herbs or potions. By default, this mod will select the one for which you have the highest income.
 
-You can also enable an option to engage abyssal waves even if fortifications are not fully upgraded, although this will reduce XP efficiency and is reccomended to be left off.
+You can also enable an option to engage abyssal waves even if fortifications are not fully upgraded, although this will reduce XP efficiency and is recommended to be left off.
 
 ## Help
 Repairing can be expensive at times, so it may be inadvisable to turn this on until your town is profitable.

--- a/main.mjs
+++ b/main.mjs
@@ -59,7 +59,12 @@ export function setup(ctx) {
         // If the repair will leave you with above the set minimum GP, repair all
         if ((game.gp.amount - repairCost > generalSettings.get("Minimum Money")) &&
             (game.township.townData.season.id != "melvorF:Winter" || generalSettings.get("repair-in-winter"))) {
-            this.repairAllBuildings();
+                // Leaving here to avoid breaking if another storage type is added
+                game.township.repairAllBuildings();
+                // For some reason game.township.repairAllBuildings() doesn't repair both individually
+                // So two seperate calls stop ItA repair costs preventing normal repair and vice versa
+                game.township.repairAllBuildingsFromStorageType('Normal');
+                game.township.repairAllBuildingsFromStorageType('Soul');
         }
 
         let resourceName = getResourceToUse(generalSettings);
@@ -99,7 +104,6 @@ function getResourceToUse(generalSettings) {
         } else {
             return "melvorF:Potions";
         }
-
     } else {
         return resourceName;
     }

--- a/main.mjs
+++ b/main.mjs
@@ -39,7 +39,7 @@ export function setup(ctx) {
         [{
             type: 'switch',
             name: 'wave-if-suboptimal',
-            label: 'Fight current wave if suboptimal?',
+            label: 'Fight Current Wave if Suboptimal?',
             hint: 'Determines if township should fight waves if fortification upgrades are available (Recommended OFF).',
             default: false
         },

--- a/main.mjs
+++ b/main.mjs
@@ -64,7 +64,9 @@ export function setup(ctx) {
                 // For some reason game.township.repairAllBuildings() doesn't repair both individually
                 // So two seperate calls stop ItA repair costs preventing normal repair and vice versa
                 game.township.repairAllBuildingsFromStorageType('Normal');
-                game.township.repairAllBuildingsFromStorageType('Soul');
+                if (game.township.canFightAbyssalWaves) {
+                    game.township.repairAllBuildingsFromStorageType('Soul');
+                }
         }
 
         let resourceName = getResourceToUse(generalSettings);
@@ -77,18 +79,20 @@ export function setup(ctx) {
         this.increaseHealth(resourceToUse, healthToHeal);
 
         // Auto Abyssal Wave Fighting
-        const armourAndWeaponary = game.township.resources.getObjectByID("melvorItA:ArmourWeaponry").amount;
-        const minimumArmourAndWeaponary = intoTheAbyssSettings.get("minimum-armour-and-weaponary");
-        const abyssalWaveSize = game.township.abyssalWaveSize;
-        const minimumArmourAndWeaponaryMet = (armourAndWeaponary - abyssalWaveSize) >= minimumArmourAndWeaponary;
+        if (game.township.canFightAbyssalWaves) {
+            const armourAndWeaponary = game.township.resources.getObjectByID("melvorItA:ArmourWeaponry").amount;
+            const minimumArmourAndWeaponary = intoTheAbyssSettings.get("minimum-armour-and-weaponary");
+            const abyssalWaveSize = game.township.abyssalWaveSize;
+            const minimumArmourAndWeaponaryMet = (armourAndWeaponary - abyssalWaveSize) >= minimumArmourAndWeaponary;
 
-        const healthSufficient = game.township.townData.health >= 100;
-        const conditionsMet = healthSufficient && game.township.canFightAbyssalWaves && game.township.canWinAbyssalWave && minimumArmourAndWeaponaryMet;
+            const healthSufficient = game.township.townData.health >= 100;
+            const conditionsMet = healthSufficient && game.township.canWinAbyssalWave && minimumArmourAndWeaponaryMet;
 
-        if (!conditionsMet) return;
+            if (!conditionsMet) return;
 
-        if (intoTheAbyssSettings.get("wave-if-suboptimal") || fortificationsUpgraded()) {
-            game.township.processAbyssalWaveOnClick();
+            if (intoTheAbyssSettings.get("wave-if-suboptimal") || fortificationsUpgraded()) {
+                game.township.processAbyssalWaveOnClick();
+            }
         }
     });
 }

--- a/main.mjs
+++ b/main.mjs
@@ -40,8 +40,15 @@ export function setup(ctx) {
             type: 'switch',
             name: 'wave-if-suboptimal',
             label: 'Fight current wave if suboptimal?',
-            hint: 'Determines if township should fight waves if fortification upgrades are available (Reccomended OFF).',
+            hint: 'Determines if township should fight waves if fortification upgrades are available (Recommended OFF).',
             default: false
+        },
+        {
+            type: 'number',
+            name: 'minimum-armour-and-weaponary',
+            label: 'Minimum Armour & Weaponary',
+            hint: 'Minimum amount of armour & weaponary left in bank for trading.',
+            default: 0,
         }]
     );
 
@@ -65,10 +72,18 @@ export function setup(ctx) {
         this.increaseHealth(resourceToUse, healthToHeal);
 
         // Auto Abyssal Wave Fighting
-        if (game.township.townData.health >= 100 && game.township.canFightAbyssalWaves && game.township.canWinAbyssalWave) {
-            if (intoTheAbyssSettings.get("wave-if-suboptimal") || fortificationsUpgraded()) {
-                game.township.processAbyssalWaveOnClick();
-            }
+        const armourAndWeaponary = game.township.resources.getObjectByID("melvorItA:ArmourWeaponry").amount;
+        const minimumArmourAndWeaponary = intoTheAbyssSettings.get("minimum-armour-and-weaponary");
+        const abyssalWaveSize = game.township.abyssalWaveSize;
+        const minimumArmourAndWeaponaryMet = (armourAndWeaponary - abyssalWaveSize) >= minimumArmourAndWeaponary;
+
+        const healthSufficient = game.township.townData.health >= 100;
+        const conditionsMet = healthSufficient && game.township.canFightAbyssalWaves && game.township.canWinAbyssalWave && minimumArmourAndWeaponaryMet;
+
+        if (!conditionsMet) return;
+
+        if (intoTheAbyssSettings.get("wave-if-suboptimal") || fortificationsUpgraded()) {
+            game.township.processAbyssalWaveOnClick();
         }
     });
 }

--- a/main.mjs
+++ b/main.mjs
@@ -30,8 +30,13 @@ export function setup(ctx) {
             label: 'Repair in Winter?',
             hint: 'Determines if township should continue repairing during winter season.',
             default: true
-        },
-        {
+        }]
+    );
+
+    const intoTheAbyssSettings = ctx.settings.section('Into the Abyss');
+
+    intoTheAbyssSettings.add(
+        [{
             type: 'switch',
             name: 'wave-if-suboptimal',
             label: 'Fight current wave if suboptimal?',
@@ -61,7 +66,7 @@ export function setup(ctx) {
 
         // Auto Abyssal Wave Fighting
         if (game.township.townData.health >= 100 && game.township.canFightAbyssalWaves && game.township.canWinAbyssalWave) {
-            if (generalSettings.get("wave-if-suboptimal") || fortificationsUpgraded()) {
+            if (intoTheAbyssSettings.get("wave-if-suboptimal") || fortificationsUpgraded()) {
                 game.township.processAbyssalWaveOnClick();
             }
         }

--- a/main.mjs
+++ b/main.mjs
@@ -8,7 +8,7 @@ export function setup(ctx) {
             type: "dropdown",
             name: "Resources",
             label: "Resources",
-            hint: "Which resource to heal your town with",
+            hint: "Which resource to heal your town with.",
             default: "Auto",
             options: [
                 { value: "Auto", display: "Auto" },
@@ -20,7 +20,7 @@ export function setup(ctx) {
             type: "number",
             name: "Minimum Money",
             label: "Minimum Money",
-            hint: "Limit minimum amount of money that mod will leave in your bank",
+            hint: "Limit minimum amount of money that mod will leave in your bank.",
             default: 0,
             min: 0
         },
@@ -73,7 +73,7 @@ export function setup(ctx) {
         let resourceToUse = game.township.resources.getObjectByID(resourceName);
 
         // Calculate amount of healing required
-        let healthToHeal = 100 - game.township.townData.health
+        let healthToHeal = 100 - game.township.townData.health;
 
         // Apply healing
         this.increaseHealth(resourceToUse, healthToHeal);

--- a/main.mjs
+++ b/main.mjs
@@ -49,6 +49,7 @@ export function setup(ctx) {
             label: 'Minimum Armour & Weaponary',
             hint: 'Minimum amount of armour & weaponary left in bank for trading.',
             default: 0,
+            min: 0
         }]
     );
 


### PR DESCRIPTION
Automatically fight abyssal waves if fortification requirements are met (can be toggle ignored) and the user can also specify the minimum amount of armor & weaponry to keep for trading (0 default). Also now both realms are repaired individually to avoid one realm stopping another from reparing.